### PR TITLE
make links optional

### DIFF
--- a/src/DocumentationOverview.jl
+++ b/src/DocumentationOverview.jl
@@ -37,6 +37,7 @@ The first argument specifies the list of APIs to be shown:
   - `:name`: use `api.name`; i.e., `A.B.C.f(x, y)` becomes `f`.
   - `:strip_namespace`: strip the namespace part; i.e., `A.B.C.f(x, y)` becomes `f(x, y)`.
   - a callabel object: it must map an `API` to a `String` which is used as a signature.
+- `links`: A `Bool` (`true` by default) indicating whether or not the signatures will be `@ref` links.
 
 Keyword arguments for [`find`](@ref) can also be passed with the method that takes
 `module::Module` .
@@ -107,6 +108,7 @@ The first argument specifies the list of APIs to be shown:
   - `:name`: use `api.name`; i.e., `A.B.C.f(x, y)` becomes `f`.
   - `:strip_namespace`: strip the namespace part; i.e., `A.B.C.f(x, y)` becomes `f(x, y)`.
   - a callabel object: it must map an `API` to a `String` which is used as a signature.
+- `links`: A `Bool` (`true` by default) indicating whether or not the signatures will be `@ref` links.
 
 Keyword arguments for [`find`](@ref) can also be passed with the method that takes
 `module::Module` .

--- a/src/list.jl
+++ b/src/list.jl
@@ -19,7 +19,8 @@ end
 
 function DocumentationOverview.list(apis; links = true, options...)
     apis, options = preprocess(apis; options...)
-    return DocList(apis; links, options...)
+    isempty(options) || throw(ArgumentError("list does not support keyword arguements $options"))
+    return DocList(apis, links)
 end
 
 DocumentationOverview.list_md(args...; options...) =

--- a/src/list.jl
+++ b/src/list.jl
@@ -1,12 +1,13 @@
 struct DocList <: Overview
     apis::Vector{API}
+    links::Bool
 end
 
 function Base.show(io::IO, ::MIME"text/markdown", list::DocList)
     for api in list.apis
         s = summarize(api)
         print(io, "* ")
-        mdlink(io, s)
+        list.links ? mdlink(io, s) : print(io, s.signature)
         text = s.text
         if text === nothing || all(isspace, text)
             println(io)
@@ -16,9 +17,9 @@ function Base.show(io::IO, ::MIME"text/markdown", list::DocList)
     end
 end
 
-function DocumentationOverview.list(apis; options...)
+function DocumentationOverview.list(apis; links = true, options...)
     apis, options = preprocess(apis; options...)
-    return DocList(apis; options...)
+    return DocList(apis; links, options...)
 end
 
 DocumentationOverview.list_md(args...; options...) =

--- a/src/table.jl
+++ b/src/table.jl
@@ -1,9 +1,10 @@
 struct DocTable <: Overview
     apis::Vector{API}
     apicolumn::String
+    links::Bool
 end
 
-DocTable(apis; apicolumn = "**API**") = DocTable(apis, apicolumn)
+DocTable(apis; apicolumn = "**API**", links = true) = DocTable(apis, apicolumn, links)
 
 function Base.show(io::IO, ::MIME"text/markdown", table::DocTable)
     println(io, "| ", table.apicolumn, " | **Summary** |")
@@ -11,7 +12,7 @@ function Base.show(io::IO, ::MIME"text/markdown", table::DocTable)
     for api in table.apis
         s = summarize(api)
         print(io, "| ")
-        mdlink(io, s)
+        table.links ? mdlink(io, s) : print(io, s.signature)
         println(io, " | ", something(s.text, ""), " |")
     end
 end

--- a/test/DocumentationOverviewTests/src/DocumentationOverviewTests.jl
+++ b/test/DocumentationOverviewTests/src/DocumentationOverviewTests.jl
@@ -3,5 +3,6 @@ module DocumentationOverviewTests
 include("test_pkgapi.jl")
 include("test_find.jl")
 include("test_table.jl")
+include("test_list.jl")
 
 end  # module DocumentationOverviewTests

--- a/test/DocumentationOverviewTests/src/test_list.jl
+++ b/test/DocumentationOverviewTests/src/test_list.jl
@@ -6,7 +6,6 @@ using Test
 function test_default()
     list = DocumentationOverview.list(DocumentationOverview)
     text = sprint(show, "text/plain", list)
-    @test startswith(text, "* ")
     @test occursin("DocumentationOverview.table", text)
     @test occursin("DocumentationOverview.find", text)
     @test occursin("DocumentationOverview.API", text)

--- a/test/DocumentationOverviewTests/src/test_list.jl
+++ b/test/DocumentationOverviewTests/src/test_list.jl
@@ -12,4 +12,24 @@ function test_default()
     @test occursin("DocumentationOverview.API", text)
 end
 
+function test_nolinks_md()
+    table = DocumentationOverview.list_md(DocumentationOverview)
+    text = sprint(show, "text/markdown", table)
+    @test occursin("DocumentationOverview.table", text)
+    @test occursin("DocumentationOverview.find", text)
+    @test occursin("DocumentationOverview.API", text)
+    num_refs = length(collect(eachmatch(r"@ref", text)))
+
+    table = DocumentationOverview.list_md(DocumentationOverview, links = false)
+    text = sprint(show, "text/markdown", table)
+    @test occursin("DocumentationOverview.table", text)
+    @test occursin("DocumentationOverview.find", text)
+    @test occursin("DocumentationOverview.API", text)
+    num_refs_nolinks = length(collect(eachmatch(r"@ref", text)))
+
+    # The description might include @ref blocks as well,
+    # we thus test that the number of refs is reduced.
+    @test num_refs_nolinks < num_refs
+end
+
 end  # module

--- a/test/DocumentationOverviewTests/src/test_table.jl
+++ b/test/DocumentationOverviewTests/src/test_table.jl
@@ -45,4 +45,24 @@ function test_nodoc()
     @test occursin("nodoc", text)
 end
 
+function test_nolinks_md()
+    table = DocumentationOverview.table_md(DocumentationOverview)
+    text = sprint(show, "text/markdown", table)
+    @test occursin("DocumentationOverview.table", text)
+    @test occursin("DocumentationOverview.find", text)
+    @test occursin("DocumentationOverview.API", text)
+    num_refs = length(collect(eachmatch(r"@ref", text)))
+
+    table = DocumentationOverview.table_md(DocumentationOverview, links = false)
+    text = sprint(show, "text/markdown", table)
+    @test occursin("DocumentationOverview.table", text)
+    @test occursin("DocumentationOverview.find", text)
+    @test occursin("DocumentationOverview.API", text)
+    num_refs_nolinks = length(collect(eachmatch(r"@ref", text)))
+
+    # The description might include @ref blocks as well,
+    # we thus test that the number of refs is reduced.
+    @test num_refs_nolinks < num_refs
+end
+
 end  # module


### PR DESCRIPTION
This PR makes links in tables and lists optional. The reason for this is that the links will lead nowhere if a table is included in a documentation that does not also include the relevant docstring. My usecase is to include a quick overview of functionality that is reexported from within the documented package but belongs to another package. 

Even better would be if I could somehow make the `@ref` link to another documentation page, but I could not figure out a robust way of doing that. 
