### PR TITLE
Move PublicAPI to Internal

### DIFF
--- a/src/DocumentationOverview.jl
+++ b/src/DocumentationOverview.jl
@@ -1,8 +1,5 @@
 baremodule DocumentationOverview
 
-import PublicAPI
-PublicAPI.@public table table_md find API
-
 """
     DocumentationOverview.table(module::Module; ...) -> table
     DocumentationOverview.table(fullnames::Expr; ...) -> table
@@ -226,5 +223,7 @@ include("table.jl")
 include("list.jl")
 
 end  # module Internal
+
+Internal.PublicAPI.@public table table_md find API
 
 end  # baremodule DocumentationOverview


### PR DESCRIPTION
Use `PublicAPI` imported in `Internal` instead of importing `PublicAPI` at the top level.